### PR TITLE
Update for syntax highlighting

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,18 +16,18 @@ No custom configuration is required at this time
 
 == First-Time Setup
 
-1. Clone the code from GitHub using `git clone https://github.com/elizabrock/tonys_pizza.git`
+1. Clone the code from GitHub using <code>git clone https://github.com/elizabrock/tonys_pizza.git</code>
 2. Read this README ;)
-3. Install dependencies using `bundle`.
+3. Install dependencies using +bundle+.
 4. Run `rake db:setup, to create databases locally for development and testing, copy the database schema to your local databases, and import sample data for running the app in development.
-5. Turn on the server with `rails s`
-6. (optional) Run `rake` (see The Test Suite, below). If everything is set up correctly, rake will pass.
+5. Turn on the server with <code>rails s</code>
+6. (optional) Run +rake+ (see The Test Suite, below). If everything is set up correctly, rake will pass.
 
 == The Test Suite
 
 This application was developed with Test-Driven Development, using the default MiniTest testing tools that come with Rails by default.
 
-Ruby the test suite with `rake`.
+Ruby the test suite with +rake+.
 
 == Photo Credits
 


### PR DESCRIPTION
Change ` to '+' and '<code></code>' to account for differences in markdown and rdoc code highlighting, see:
https://github.com/rdoc/rdoc/blob/master/ExampleRDoc.rdoc for sources.
